### PR TITLE
fix: fetch Git history when performing a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          fetch-depth: 0
       - name: Get previous tag for the change log
         id: previousTag
         run: |


### PR DESCRIPTION
We need to the Git history to find the previous tag

Before opening a 'pull request'

* Search existing issues and pull requests to see if the issue was already discussed.
* Check our discussions to see if the issue was already discussed.
* Check for specific project we support to raise the issue on, under [spotbugs](https://github.com/spotbugs)
* Do not open intellij plugin issues here, open them at [intellij-plugin](https://github.com/JetBrains/spotbugs-intellij-plugin) *
